### PR TITLE
Implement admin mode with teacher-only activity changes

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,9 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Sign up for activities (teacher login required)
+- Unregister students from activities (teacher login required)
+- Teacher admin mode with login/logout controls
 
 ## Getting Started
 
@@ -31,6 +33,19 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Remove a student from an activity                                |
+| POST   | `/auth/login`                                                     | Teacher login                                                       |
+| POST   | `/auth/logout`                                                    | Teacher logout                                                      |
+| GET    | `/auth/status`                                                    | Check login status                                                  |
+
+## Teacher Credentials
+
+Teacher credentials are stored in `src/teachers.json`.
+
+Default demo accounts:
+
+- `teacher1` / `mergington123`
+- `teacher2` / `activities456`
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,13 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
+from pydantic import BaseModel
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import json
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +21,17 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+
+def load_teachers() -> dict:
+    teachers_path = current_dir / "teachers.json"
+    with open(teachers_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("teachers", {})
+
+
+teachers = load_teachers()
+active_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -78,6 +92,19 @@ activities = {
 }
 
 
+class LoginPayload(BaseModel):
+    username: str
+    password: str
+
+
+def require_teacher(request: Request) -> str:
+    token = request.cookies.get("teacher_session")
+    username = active_sessions.get(token)
+    if not username:
+        raise HTTPException(status_code=403, detail="Teacher login required")
+    return username
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,9 +115,44 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def login(payload: LoginPayload, response: Response):
+    expected_password = teachers.get(payload.username)
+    if not expected_password or expected_password != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(24)
+    active_sessions[token] = payload.username
+    response.set_cookie(
+        key="teacher_session",
+        value=token,
+        httponly=True,
+        samesite="lax",
+    )
+    return {"message": "Login successful", "username": payload.username}
+
+
+@app.post("/auth/logout")
+def logout(request: Request, response: Response):
+    token = request.cookies.get("teacher_session")
+    if token in active_sessions:
+        del active_sessions[token]
+    response.delete_cookie("teacher_session")
+    return {"message": "Logged out"}
+
+
+@app.get("/auth/status")
+def auth_status(request: Request):
+    token = request.cookies.get("teacher_session")
+    username = active_sessions.get(token)
+    return {"authenticated": bool(username), "username": username}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, request: Request):
     """Sign up a student for an activity"""
+    require_teacher(request)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +173,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, request: Request):
     """Unregister a student from an activity"""
+    require_teacher(request)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,54 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const authStatus = document.getElementById("auth-status");
+  const userMenuBtn = document.getElementById("user-menu-btn");
+  const authMenu = document.getElementById("auth-menu");
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loginModal = document.getElementById("login-modal");
+  const closeModalBtn = document.getElementById("close-modal-btn");
+  const loginForm = document.getElementById("login-form");
+  let isTeacher = false;
+  let currentTeacher = null;
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUI() {
+    if (isTeacher) {
+      authStatus.textContent = `Logged in as teacher: ${currentTeacher}`;
+      loginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+      signupForm.classList.remove("hidden");
+    } else {
+      authStatus.textContent = "Viewing as student (read-only mode)";
+      loginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      signupForm.classList.add("hidden");
+    }
+  }
+
+  async function loadAuthStatus() {
+    try {
+      const response = await fetch("/auth/status");
+      const data = await response.json();
+      isTeacher = data.authenticated;
+      currentTeacher = data.username;
+      updateAuthUI();
+    } catch (error) {
+      isTeacher = false;
+      currentTeacher = null;
+      updateAuthUI();
+      console.error("Error loading auth status:", error);
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +78,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isTeacher
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +121,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!isTeacher) {
+      showMessage("Only teachers can unregister students.", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -86,26 +143,15 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -113,6 +159,11 @@ document.addEventListener("DOMContentLoaded", () => {
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!isTeacher) {
+      showMessage("Only teachers can register students.", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -130,31 +181,83 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userMenuBtn.addEventListener("click", () => {
+    authMenu.classList.toggle("hidden");
+  });
+
+  loginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    authMenu.classList.add("hidden");
+  });
+
+  closeModalBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/auth/logout", { method: "POST" });
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result.detail || "Logout failed");
+      }
+      isTeacher = false;
+      currentTeacher = null;
+      updateAuthUI();
+      fetchActivities();
+      showMessage(result.message, "success");
+    } catch (error) {
+      showMessage("Failed to logout.", "error");
+      console.error("Error logging out:", error);
+    }
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      isTeacher = true;
+      currentTeacher = result.username;
+      updateAuthUI();
+      fetchActivities();
+      loginModal.classList.add("hidden");
+      loginForm.reset();
+      showMessage(result.message, "success");
+    } catch (error) {
+      showMessage("Login failed. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  loadAuthStatus().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -7,9 +7,18 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <div class="auth-controls">
+      <button id="user-menu-btn" class="icon-btn" type="button" aria-label="User menu">👤</button>
+      <div id="auth-menu" class="auth-menu hidden">
+        <button id="login-btn" type="button">Login</button>
+        <button id="logout-btn" type="button" class="hidden">Logout</button>
+      </div>
+    </div>
+
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <p id="auth-status" class="auth-status">Viewing as student</p>
     </header>
 
     <main>
@@ -44,6 +53,26 @@
     <footer>
       <p>&copy; 2026 Mergington High School</p>
     </footer>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-content">
+        <h3 id="login-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Sign In</button>
+            <button id="close-modal-btn" type="button">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -13,6 +13,40 @@ body {
   margin: 0 auto;
   padding: 20px;
   background-color: #f5f5f5;
+  position: relative;
+}
+
+.auth-controls {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  z-index: 20;
+}
+
+.icon-btn {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: none;
+  background-color: #ffffff;
+  color: #1a237e;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.auth-menu {
+  margin-top: 8px;
+  background: #ffffff;
+  border-radius: 6px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+  padding: 8px;
+  min-width: 120px;
+}
+
+.auth-menu button {
+  width: 100%;
+  margin: 4px 0;
 }
 
 header {
@@ -26,6 +60,12 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+.auth-status {
+  margin-top: 8px;
+  font-size: 14px;
+  opacity: 0.95;
 }
 
 main {
@@ -197,4 +237,27 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal-content {
+  background: #ffffff;
+  width: min(420px, 92%);
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": {
+    "teacher1": "mergington123",
+    "teacher2": "activities456"
+  }
+}


### PR DESCRIPTION
## Summary
Implements issue #5 by adding teacher authentication and restricting enrollment modifications to logged-in teachers.

## Changes
- Added teacher login/logout/status API endpoints
- Added cookie-based teacher session handling in backend
- Restricted `signup` and `unregister` endpoints to authenticated teachers
- Added top-right user menu and teacher login modal in UI
- Updated frontend to:
  - Show read-only student mode by default
  - Allow signup/unregister only in teacher mode
  - Keep participant viewing available to all users
- Added `src/teachers.json` for demo teacher credentials
- Updated project README with auth endpoints and teacher credentials

## Default demo credentials
- `teacher1` / `mergington123`
- `teacher2` / `activities456`

## Notes
- This keeps account management simple per issue request by using a JSON file.
- Students can still view registered participants, but only teachers can modify enrollment.

Closes #5